### PR TITLE
Keyword arguments have to be explicitly double-splatted in Ruby 2.7+

### DIFF
--- a/lib/mysql2/error.rb
+++ b/lib/mysql2/error.rb
@@ -52,7 +52,7 @@ module Mysql2
     def initialize(msg, server_version = nil, error_number = nil, sql_state = nil)
       @server_version = server_version
       @error_number = error_number
-      @sql_state = sql_state ? sql_state.encode(ENCODE_OPTS) : nil
+      @sql_state = sql_state ? sql_state.encode(**ENCODE_OPTS) : nil
 
       super(clean_message(msg))
     end
@@ -91,9 +91,9 @@ module Mysql2
     # Returns a valid UTF-8 string.
     def clean_message(message)
       if @server_version && @server_version > 50500
-        message.encode(ENCODE_OPTS)
+        message.encode(**ENCODE_OPTS)
       else
-        message.encode(Encoding::UTF_8, ENCODE_OPTS)
+        message.encode(Encoding::UTF_8, **ENCODE_OPTS)
       end
     end
   end


### PR DESCRIPTION
Bringing in this from upstream: https://github.com/brianmario/mysql2/pull/1084 to give us Ruby 3 compatibility.