### PR TITLE
MariaDB client support

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -1221,6 +1221,7 @@ static VALUE initialize_ext(VALUE self) {
 }
 
 void init_mysql2_client() {
+#ifdef _WIN32
   /* verify the libmysql we're about to use was the version we were built against
      https://github.com/luislavena/mysql-gem/commit/a600a9c459597da0712f70f43736e24b484f8a99 */
   int i;
@@ -1238,6 +1239,7 @@ void init_mysql2_client() {
       return;
     }
   }
+#endif
 
   /* Initializing mysql library, so different threads could call Client.new */
   /* without race condition in the library */

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -1309,6 +1309,10 @@ void init_mysql2_client() {
 #ifdef CLIENT_LONG_PASSWORD
   rb_const_set(cMysql2Client, rb_intern("LONG_PASSWORD"),
       LONG2NUM(CLIENT_LONG_PASSWORD));
+#else
+  /* HACK because MariaDB 10.2 no longer defines this constant,
+   * but we're using it in our default connection flags. */
+  rb_const_set(cMysql2Client, rb_intern("LONG_PASSWORD"), INT2NUM(0));
 #endif
 
 #ifdef CLIENT_FOUND_ROWS

--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -29,7 +29,7 @@ dirs = ENV['PATH'].split(File::PATH_SEPARATOR) + %w[
   /usr/local/lib/mysql5
 ].map{|dir| "#{dir}/bin" }
 
-GLOB = "{#{dirs.join(',')}}/{mysql_config,mysql_config5}"
+GLOB = "{#{dirs.join(',')}}/{mysql_config,mysql_config5,mariadb_config}"
 
 # If the user has provided a --with-mysql-dir argument, we must respect it or fail.
 inc, lib = dir_config('mysql')

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -297,7 +297,7 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, ID db_timezone, ID app_timezo
             break;
           }
           msec = msec_char_to_uint(msec_char, sizeof(msec_char));
-          val = rb_funcall(rb_cTime, db_timezone, 6, opt_time_year, opt_time_month, opt_time_month, UINT2NUM(hour), UINT2NUM(min), UINT2NUM(sec), UINT2NUM(msec));
+          val = rb_funcall(rb_cTime, db_timezone, 7, opt_time_year, opt_time_month, opt_time_month, UINT2NUM(hour), UINT2NUM(min), UINT2NUM(sec), UINT2NUM(msec));
           if (!NIL_P(app_timezone)) {
             if (app_timezone == intern_local) {
               val = rb_funcall(val, intern_localtime, 0);


### PR DESCRIPTION
Supports the Backpack Ruby 2.5.9 upgrade: https://github.com/basecamp/backpack/pull/247

I've cherry picked some commits, and adapted one from the Makandra mysql2 LTS branch: https://github.com/makandra/mysql2/tree/0.2.x-lts

These commits mean that we can use the official Ruby docker images, which are based on Debian, where the mysql client is less readily available. Now we can use a more recent version of Debian.

Please see the individual commits.

cc @basecamp/sip 