### PR TITLE
Mark Result's fieldTypes so the GC can see it

### DIFF
--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -62,6 +62,7 @@ static void rb_mysql_result_mark(void * wrapper) {
   mysql2_result_wrapper * w = wrapper;
   if (w) {
     rb_gc_mark(w->fields);
+    rb_gc_mark(w->fieldTypes);
     rb_gc_mark(w->rows);
     rb_gc_mark(w->encoding);
     rb_gc_mark(w->client);


### PR DESCRIPTION
bc3, launchpad and queenbee all ship this fork as `mysql2 0.5.4.latin1utf8`, so this is the copy that actually matters to us. Same defect as upstream, filed there as brianmario/mysql2#1454.

`mysql2_result_wrapper` is xmalloc'd, so the collector neither scans it nor updates it — every `VALUE` in it has to be marked by hand. `fieldTypes` is declared in `result.h:9` but missing from `rb_mysql_result_mark`, which marks exactly `fields`, `rows`, `encoding`, `client` and `statement`. Nothing else marks it.

This fork is pre-TypedData (`Data_Get_Struct`, non-movable `rb_gc_mark`, no compact function), so unlike upstream it needs one line rather than two. Compaction is irrelevant here either way — ordinary GC is enough.

## The window is inside the allocating call

`rb_mysql_result_fetch_field_types` allocates the Array and stores it in `wrapper->fieldTypes`; the fill loop then calls `rb_mysql_result_fetch_field_type` per column, which allocates Strings and can trigger a GC; `rb_ary_store` afterwards writes through a freed object slot. So it's a write into whatever now occupies that slot, not only a bad read.

## Reproducing

Public API only — no `Fiddle`, no raw memory access, so a crash can only come from the extension:

```ruby
res = client.query("select 1 as a, 'x' as b, 2.5 as c, now() as d")
GC.stress = true
types = res.field_types      # first-ever call on this Result
GC.stress = false
raise "not an Array: #{types.class}" unless types.is_a?(Array)
```

Both trees built inside the same step that ran the test, so the artifact can't drift from the source:

```
                     fork HEAD   with this patch
GC.stress, 1 call    3/3 abort   3/3 pass
GC off (control)     3/3 pass    3/3 pass
```

`GC.stress` only makes it deterministic. Without it — ordinary GC, allocation churn between calls, no `GC.start`, no compaction — upstream master segfaults within the first 25 calls, 5/5, while the patched build completes 60,000 calls 3/3.

Ruby 4.0.6, MySQL 9.6, in a container.

## Reachability

`Result#field_types` is public and is what `each(as: :hash)` type-casting goes through, so anything reading rows off this driver is on the path. Found while sweeping our native gems for dangling `VALUE`s.